### PR TITLE
Melhora performance das consultas de feriado

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,10 @@ Por padrão a cidade e estado consultado é São Paulo. Com os valores utilizado
 - Cidade: 'SAO_PAULO'
 - Estado: 'SP'
 
-Foi cadastrado um token prévio para realizar a consulta nessa API. Sinta-se livre para inserir o seu diretamente no arquivo de [configurações](./helpers/feriados-municipais/config.js) ou através do parâmetro **token** através de **process.env** ao executar o programa, como é necessário informar as datas iniciais e finais. Por exemplo:
+Foi cadastrado um token prévio para realizar a consulta nessa API. Sinta-se livre para inserir o seu diretamente no arquivo de [configurações](./config/calendario.json), ou alterar a cidade e estado da consulta.
+
+Caso prefira, você pode passar esses valores ao executar a aplicação também (via **process.env**), como:
 
 ```sh
-inicio=data_inicio fim=data_fim token=meu_token npm start
-```
-
-Caso deseje realizar a consulta utilizando outra cidade/estado, seguindo a documentação da API de Calendário, basta passar esses valores ao executar a aplicação também, como:
-
-```sh
-inicio=data_inicio fim=data_fim cidade=minha_cidade estado=meu_estado npm start
+inicio=data_inicio fim=data_fim cidade=minha_cidade estado=meu_estado token=meu_token npm start
 ```

--- a/config/calendario.json
+++ b/config/calendario.json
@@ -1,0 +1,6 @@
+{
+    "url": "https://api.calendario.com.br/",
+    "token": "Z2FicmllbC5sdWl6LnJhbW9zQGdtYWlsLmNvbSZoYXNoPTIyMzMyMTE1OQ",
+    "cidade": "SAO_PAULO",
+    "estado": "SP"
+}

--- a/helpers/feriados-municipais/config.js
+++ b/helpers/feriados-municipais/config.js
@@ -1,7 +1,9 @@
-const DOMINIO_API = 'https://api.calendario.com.br/';
-const TOKEN = `token=${process.env.token || 'Z2FicmllbC5sdWl6LnJhbW9zQGdtYWlsLmNvbSZoYXNoPTIyMzMyMTE1OQ'}`;
-const CIDADE = `cidade=${process.env.cidade || 'SAO_PAULO'}`;
-const ESTADO = `estado=${process.env.estado || 'SP'}`;
+const calendarioConfig = require('../../config/calendario.json');
+
+const DOMINIO_API = calendarioConfig.url;
+const TOKEN = `token=${process.env.token || calendarioConfig.token}`;
+const CIDADE = `cidade=${process.env.cidade || calendarioConfig.cidade}`;
+const ESTADO = `estado=${process.env.estado || calendarioConfig.estado}`;
 const ANO = ano => `ano=${ano || new Date().getFullYear()}`;
 
 const API = ano => `${DOMINIO_API}?${ANO(ano)}&${ESTADO}&${CIDADE}&${TOKEN}`;

--- a/helpers/feriados-municipais/index.js
+++ b/helpers/feriados-municipais/index.js
@@ -6,19 +6,30 @@ const getApiURL = require('./config');
 
 const {formatDateToBr} = require('../formatters');
 
-async function ehDiaUtilMunicipal(data) {
-    const dataObj = new Date(data);
-    const ano = dataObj.getFullYear();
-    const API = getApiURL(ano);
- 
-    const dataPadraoBr = formatDateToBr(data);
+const feriados = {};
 
+const anoFoiConsultado = ano => Object.keys(feriados).includes(ano.toString());
+
+async function consultaFeriadoMunicipal (ano) {
+    const API = getApiURL(ano);
     const response = await fetch(API);
     const responseText = await response.text();
     const JSONdata = JSON.parse(parser.toJson(responseText));
     const feriadosMunicipais = JSONdata.events.event;
+    
+    feriados[ano] = feriadosMunicipais;
 
-    const ehFeriadoMunicipal = feriadosMunicipais.some(evento => evento.date === dataPadraoBr);
+    return feriados[ano]
+}
+
+async function ehDiaUtilMunicipal(data) {
+    const dataObj = new Date(data);
+    const ano = dataObj.getFullYear();
+    const dataPadraoBr = formatDateToBr(data);
+
+    const _feriados = !anoFoiConsultado(ano) ? await consultaFeriadoMunicipal(ano) : feriados[ano];
+
+    const ehFeriadoMunicipal = _feriados.some(evento => evento.date === dataPadraoBr);
     
     return ehFeriadoMunicipal;
 }

--- a/ponto.js
+++ b/ponto.js
@@ -34,8 +34,9 @@ async function corrigePonto(inicio, fim) {
     while (dataCorrente <= dataFinal) {
         const formattedDate = formateDateToISO(dataCorrente);
         const weekday = delorean.setDate(formattedDate).getWeekDay('long');
+        const deveCorrigirPonto = await ehDiaUtil(dataCorrente); 
 
-        if (await ehDiaUtil(dataCorrente)) {
+        if (deveCorrigirPonto) {
             disparaPonto(formattedDate);
         }
         else {


### PR DESCRIPTION
Realiza uma melhoria de performance (na funcionalidade de consulta de feriados municipais, adicionado no PR #3) , armazenando os feriados após consulta e verificando antes de realizar uma nova chamada à API.

Também cria um arquivo de configuração pra API de Calendário e atualiza o README.