### PR TITLE
Randomize minutes of custom time on -10,10 range with self completude

### DIFF
--- a/helpers/formatters.js
+++ b/helpers/formatters.js
@@ -2,9 +2,14 @@ const buildPayload = require('../helpers/build-payload');
 const customTimes = require('./custom-times');
 const delorean = require('@gabrieluizramos/delorean-js');
 
-function formataPayload(data) {
+function formataPayload(data, random) {
     const weekDay = delorean.setDate(data).getWeekDay('short');
     const horarios = customTimes(weekDay);
+
+    if(random) {
+        return buildPayload(data, randomizeHours(horarios), weekDay);
+    }
+
     return buildPayload(data, horarios, weekDay);
 }
 
@@ -13,6 +18,34 @@ const formatNumberWith2Digits = (number) => number < 10 ? `0${number}` : number;
 const formatDateToBr = (date) => `${formatNumberWith2Digits(date.getDate())}/${formatNumberWith2Digits(date.getMonth() + 1)}/${date.getFullYear()}`;
 
 const formateDateToISO = (date) => `${date.getFullYear()}-${formatNumberWith2Digits(date.getMonth() + 1)}-${formatNumberWith2Digits(date.getDate())}`;
+
+function randomizeHours(hours) {
+    return hours.map((hour, index) => {
+        if(index % 2 == 0) {
+            random = getRandomInt(-10, 10)
+        } else {
+            random = random * -1
+        }
+        
+        hourParts = hour.split(":")
+        
+        date = new Date()
+        date.setUTCHours(parseInt(hourParts[0]), parseInt(hourParts[1]), 0, 0)
+        date = addMinutes(date, random)
+
+        return formatNumberWith2Digits(date.getUTCHours())+":"+formatNumberWith2Digits(date.getUTCMinutes())
+    })
+}
+
+function getRandomInt(min, max) {
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min)) + min;
+}
+
+function addMinutes(date, minutes) {
+    return new Date(date.getTime() + minutes*60000);
+}
 
 module.exports = {
     formataPayload,

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 const registra = require('./ponto');
 
-registra({inicio: process.env.inicio, fim: process.env.fim});
+registra({inicio: process.env.inicio, fim: process.env.fim, random: process.env.random});

--- a/ponto.js
+++ b/ponto.js
@@ -13,11 +13,11 @@ const {formataPayload, formateDateToISO} = require('./helpers/formatters');
 const ehDiaUtil = require('./helpers/eh-dia-util');
 
 
-function disparaPonto (data) {
+function disparaPonto (data, random) {
     fetch(url, {
         method: 'POST',
         headers: user,
-        body: JSON.stringify(formataPayload(data))
+        body: JSON.stringify(formataPayload(data, random))
     })
     .then(res => res.json())
     .then(res => {
@@ -33,7 +33,7 @@ function disparaPonto (data) {
     .then(() => console.log(messages.separator));
 }
 
-async function corrigePonto(inicio, fim) {
+async function corrigePonto(inicio, fim, random) {
     const parseInicio = inicio.split('-');
     const parseFim = fim.split('-');
     const dataInicial = new Date(parseInicio[0], parseInicio[1] -1 , parseInicio[2]);
@@ -47,7 +47,7 @@ async function corrigePonto(inicio, fim) {
         const deveCorrigirPonto = await ehDiaUtil(dataCorrente); 
 
         if (deveCorrigirPonto) {
-            disparaPonto(formattedDate);
+            disparaPonto(formattedDate, random);
         }
         else {
             console.log(messages.notWorkingDay.replace('[#data#]', formattedDate).replace('[#dia-da-semana#]', weekday));
@@ -57,9 +57,9 @@ async function corrigePonto(inicio, fim) {
     }
 }
 
-function tamoAquiNaRetroatividade({inicio, fim}) {
+function tamoAquiNaRetroatividade({inicio, fim, random}) {
     if (inicio.trim() && fim.trim() && dataEhValida(inicio, fim)) {
-        corrigePonto(inicio, fim);
+        corrigePonto(inicio, fim, random);
     }
     else {
         console.log(messages.invalidDate);


### PR DESCRIPTION
This commit adds a random value normaliser to the defined custom-time, it auto changes a little each time declared there to look less suspicious, it will make the array of hours looks this way:

```
[ '09:00', '12:00', '13:00', '19:00' ]
```

that will be converted to:

```
[ '09:05', '11:55', '12:53', '19:07' ]
```

To avoid any problems on current use I added a new parameter to use this feature. So to use it you should:

`inicio=2019-03-25 fim=2019-03-25 random=true npm start`

Tested:

![device-2019-05-22-082450](https://user-images.githubusercontent.com/6535255/58170926-22480180-7c6b-11e9-9aab-a198be45e957.png)
